### PR TITLE
Fix CI pytest install and trunk config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         python-version: ["3.10", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -31,7 +31,7 @@ jobs:
         run: |
           python --version
           which python
-          python -m pip install .
+          python -m pip install ".[test]"
 
       - name: Run pytest on tests/
         run: python -m pytest ./tests/ -vvv

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -12,12 +12,13 @@ on:
   schedule:
     - cron: "0 0 1 * *"
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   trunk:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   trunk:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,7 +17,7 @@ lint:
     - bandit@1.8.3
     - checkov@3.2.390
     - ruff@0.11.1
-    - trivy@0.60.0
+    - trivy@0.73.0
     - yamllint@1.36.2
     - oxipng@9.1.4
     - actionlint@1.7.7

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -31,9 +31,6 @@ lint:
     - prettier@3.5.3
     - taplo@0.9.3
   ignore:
-    - linters: [prettier]
-      paths:
-        - SI.md
     - linters: [cspell]
       paths:
         - tests/test_molecule.py


### PR DESCRIPTION
CI has been red since the transplant, for two independent reasons:

- `ci.yml` still ran `pip install .`, but pytest moved to the `[test]` extra in the pre-tag pyproject fixes, so every matrix job failed with `No module named pytest` before running a single test.
- `.trunk/trunk.yaml` kept a prettier-ignore entry for `SI.md`, a file deliberately excluded from the migration; trunk treats a config entry pointing at a missing file as a hard error (`trunk/config-error`).

Also bumps `actions/checkout` v3→v5 and `actions/setup-python` v4→v6 in the two affected workflows (the logs warn about the Node 20 deprecation for these pins).

The checks on this PR are the verification: all six CI matrix jobs should now reach and run the full pytest suite, and trunk should come up green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)