### PR TITLE
improve project maintenance and release infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a defect in G2RINS
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A concise description of what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Smallest code snippet that triggers the problem, including the G2RINS input string when applicable.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead — paste the full traceback or error output if there is one.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: G2RINS version
+      description: Output of `python -c "import g2rins; print(g2rins.__version__)"`, or the tag/commit you installed.
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Relevant dependency versions
+      description: Especially RDKit (`python -c "import rdkit; print(rdkit.__version__)"`) when molecule generation is involved.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an improvement or new capability for G2RINS
+labels: [enhancement]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: The scientific or practical problem you are trying to solve.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired-behavior
+    attributes:
+      label: Desired behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-api
+    attributes:
+      label: Proposed API or representation
+      description: Optional sketch of the interface or G2RINS syntax you have in mind.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD041 -->
+
 ## Summary
 
 <!-- What does this PR change? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR change? -->
+
+## Motivation
+
+<!-- Why is the change needed? Link related issues. -->
+
+## Type of change
+
+<!-- Bug fix / new feature / maintenance / documentation -->
+
+## Scientific/behavioral impact
+
+<!-- Does this change grammar semantics, generation behavior, or numerical results? If yes, describe how. -->
+
+## Testing
+
+<!-- What you ran locally, and any new tests added. -->
+
+## Checklist
+
+- [ ] Tests added/updated where behavior changed
+- [ ] Existing tests pass locally (`python -m pytest tests/`)
+- [ ] Documentation and `CHANGELOG.md` updated where user-facing
+- [ ] No unrelated changes included

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - trunk-merge/**
   pull_request:
     branches:
       - main
@@ -14,14 +13,26 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs when a PR is updated; push/schedule runs get unique
+# groups and are never cancelled.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  ci-tests:
-    runs-on: ${{ matrix.os }}
+  # Fast pre-merge gate: Linux only, minimum supported Python and the highest
+  # version currently tested. The full OS matrix runs post-merge.
+  pr-tests:
+    name: PR Tests (Python ${{ matrix.python-version }})
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        # Min/max supported Python; 3.14 is the current ceiling (RDKit ships 3.14 wheels since 2026.3).
-        python-version: ["3.10", "3.14"]
+        python-version:
+          - "3.10"
+          - "3.14"
 
     steps:
       - uses: actions/checkout@v7
@@ -34,11 +45,66 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: pip install g2rins local package
+      - name: Install test environment
         run: |
           python --version
           python -c "import sys; print(sys.executable)"
           python -m pip install ".[test]"
 
-      - name: Run pytest on tests/
-        run: python -m pytest ./tests/ -vvv
+      - name: Run tests
+        run: python -m pytest tests/ -vvv
+
+  # Full compatibility matrix after merges to main and on the monthly schedule.
+  full-tests:
+    name: Full Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        python-version:
+          - "3.10"
+          - "3.14"
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # setuptools-scm needs the full history and tags to derive the version.
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test environment
+        run: |
+          python --version
+          python -c "import sys; print(sys.executable)"
+          python -m pip install ".[test]"
+
+      - name: Run tests
+        run: python -m pytest tests/ -vvv
+
+  # Stable check name for branch protection / Rulesets, independent of the
+  # matrix-generated job names.
+  ci-required:
+    name: CI Required
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+      - pr-tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify PR test matrix passed
+        env:
+          TEST_RESULT: ${{ needs.pr-tests.result }}
+        shell: bash
+        run: |
+          echo "PR test matrix result: ${TEST_RESULT}"
+          test "${TEST_RESULT}" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,33 @@ on:
   schedule:
     - cron: "0 0 1 * *"
 
+permissions:
+  contents: read
+
 jobs:
   ci-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.13"]
+        # Min/max supported Python; 3.14 is the current ceiling (RDKit ships 3.14 wheels since 2026.3).
+        python-version: ["3.10", "3.14"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
+        with:
+          # setuptools-scm needs the full history and tags to derive the version.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: pip install g2rins local package
         run: |
           python --version
-          which python
+          python -c "import sys; print(sys.executable)"
           python -m pip install ".[test]"
 
       - name: Run pytest on tests/

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -1,12 +1,12 @@
 name: notebooks
 
-# Manual-dispatch only: the guide has no TESTING_ENV fast path, so a full run
-# generates every ensemble in the paper SI across the whole OS/Python matrix.
+# Manual-dispatch only: a full run executes the guide end-to-end and generates
+# every ensemble in the paper SI across the whole OS/Python matrix.
 on:
   workflow_dispatch:
 
-env:
-  TESTING_ENV: "True"
+permissions:
+  contents: read
 
 jobs:
   notebook:
@@ -14,13 +14,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
+        with:
+          # setuptools-scm needs the full history and tags to derive the version.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.x"
+          # Pin release builds to the highest CI-tested Python; a floating
+          # "3.x" would silently adopt new releases before CI covers them.
+          python-version: "3.14"
 
       - name: Build sdist and wheel
         run: |
@@ -38,6 +40,8 @@ jobs:
         run: python -m twine check --strict dist/*
 
       - name: Store the distribution packages
+        # Only the tag-triggered github-release job consumes this artifact.
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,17 @@
-name: Build Python distribution
-permissions: read-all
+name: release
+
 on:
   push:
     branches:
       - main
-    tags: "*" # Trigger on all tags
+    tags:
+      - "v*"
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -15,18 +19,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          # setuptools-scm needs the full history and tags to derive the version.
+          fetch-depth: 0
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
-      - name: Install pypa/build
+
+      - name: Build sdist and wheel
         run: |
-          python3 -m pip install --user --upgrade build
-      - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+          python -m pip install --upgrade build twine
+          python -m build
+
+      - name: Check built distributions
+        run: python -m twine check --strict dist/*
+
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
+
+  github-release:
+    name: Create GitHub Release
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download the distribution packages
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create GitHub Release for the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release create "$GITHUB_REF_NAME" dist/*
+          --repo "$GITHUB_REPOSITORY"
+          --title "$GITHUB_REF_NAME"
+          --generate-notes
+          --verify-tag

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - trunk-merge/**
   pull_request:
     branches:
       - main
@@ -18,6 +17,7 @@ permissions:
 
 jobs:
   trunk:
+    name: Trunk Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1

--- a/.trunk/config/.cspell.json
+++ b/.trunk/config/.cspell.json
@@ -172,6 +172,14 @@
     "arrowstyle",
     "connectionstyle",
     "checkin",
-    "edgelist"
+    "edgelist",
+    "depablolab",
+    "cff",
+    "sdist",
+    "twine",
+    "keepachangelog",
+    "reproducer",
+    "pyproject",
+    "svg"
   ]
 }

--- a/.trunk/config/.cspell.json
+++ b/.trunk/config/.cspell.json
@@ -180,6 +180,8 @@
     "keepachangelog",
     "reproducer",
     "pyproject",
-    "svg"
+    "svg",
+    "RINS",
+    "docstrings"
   ]
 }

--- a/.trunk/plugins/trunk
+++ b/.trunk/plugins/trunk
@@ -1,1 +1,0 @@
-/home/gervasio-lab/.cache/trunk/plugins/https---github-com-trunk-io-plugins/v1.6.7-4ebadccd80b22638

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -49,9 +49,3 @@ actions:
     - trunk-upgrade-available
     - trunk-fmt-pre-commit
     - trunk-check-pre-push
-merge:
-  required_statuses:
-    - trunk
-    - ci-tests (ubuntu-latest)
-    - ci-tests (windows-latest)
-    - ci-tests (macos-latest)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@ Notable, user-visible changes to G²RINS. The format is based on [Keep a Changel
 
 ### Changed
 
-- CI test matrix upper bound raised from Python 3.13 to 3.14 (RDKit ≥ 2026.3 publishes Python 3.14 wheels).
-- All workflows updated to current GitHub Action majors, with least-privilege permissions and full-history checkouts so `setuptools-scm` derives the real tag version.
-- Simplified the `setuptools-scm` configuration in `pyproject.toml` to the documented pattern (no behavioral change to `g2rins.__version__`).
+- Pull requests now run a faster Linux-only Python 3.10/3.14 test matrix, while the full Linux/Windows/macOS compatibility matrix runs after merges to `main` and on the monthly schedule. Python 3.14 replaces 3.13 as the highest version tested in CI (RDKit ≥ 2026.3 publishes Python 3.14 wheels).
+- Updated official GitHub Actions to current stable majors and tightened workflow permissions.
+- Packaging and installation workflows fetch full Git history and tags so `setuptools-scm` can derive versions reliably.
+- Simplified the `setuptools-scm` configuration in `pyproject.toml` while preserving `g2rins.__version__`.
 
 ### Fixed
 
-- CI installs the `[test]` extra so pytest is available in the test jobs (#1).
-- Distribution builds previously ran on a shallow, tag-less checkout, producing a fallback development version instead of the tag-derived one.
-- Removed a machine-local `.trunk/plugins/trunk` symlink from version control.
+- CI explicitly installs the `[test]` extra so pytest is available in test jobs (#1).
+- Removed a machine-local `.trunk/plugins/trunk` artifact from version control.
 
 ## [1.0.0] - 2026-08-08
 
 Initial public release.
 
 [Unreleased]: https://github.com/depablolab/g2rins/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/depablolab/g2rins/releases/tag/v1.0.0
+[1.0.0]: https://github.com/depablolab/g2rins/tree/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+Notable, user-visible changes to G²RINS. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions correspond to the repository's `v*` git tags.
+
+## [Unreleased]
+
+### Added
+
+- `CONTRIBUTING.md`, `CITATION.cff`, this changelog, issue forms, and a pull request template.
+- GitHub Release automation for future `v*` tags: build, verify, attach wheel/sdist, and generate release notes.
+
+### Changed
+
+- CI test matrix upper bound raised from Python 3.13 to 3.14 (RDKit ≥ 2026.3 publishes Python 3.14 wheels).
+- All workflows updated to current GitHub Action majors, with least-privilege permissions and full-history checkouts so `setuptools-scm` derives the real tag version.
+- Simplified the `setuptools-scm` configuration in `pyproject.toml` to the documented pattern (no behavioral change to `g2rins.__version__`).
+
+### Fixed
+
+- CI installs the `[test]` extra so pytest is available in the test jobs (#1).
+- Distribution builds previously ran on a shallow, tag-less checkout, producing a fallback development version instead of the tag-derived one.
+- Removed a machine-local `.trunk/plugins/trunk` symlink from version control.
+
+## [1.0.0] - 2026-08-08
+
+Initial public release.
+
+[Unreleased]: https://github.com/depablolab/g2rins/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/depablolab/g2rins/releases/tag/v1.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+title: "G2RINS"
+abstract: "Implementation of G2RINS, a line-and-graph representation of polymers. Grammar validation, generative graph construction, and molecular ensemble generation."
+authors:
+  - family-names: Zaldivar
+    given-names: Gervasio
+  - family-names: Tian
+    given-names: Yuan
+license: GPL-3.0-only
+repository-code: "https://github.com/depablolab/g2rins"
+version: 1.0.0
+date-released: "2026-08-08"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to G²RINS
+
+Thanks for your interest in improving G²RINS!
+
+## Development setup
+
+Requires Python ≥ 3.10.
+
+```bash
+git clone https://github.com/depablolab/g2rins.git
+cd g2rins
+python -m pip install -e ".[test]"
+```
+
+## Running tests
+
+```bash
+python -m pytest tests/
+```
+
+CI runs the same suite on Linux, Windows, and macOS with the minimum (3.10) and maximum (3.14) supported Python versions, so passing locally on one platform is usually enough before opening a pull request.
+
+## Contribution workflow
+
+We use plain GitHub flow — short-lived branches off `main`, merged back via pull request. There is no `develop` branch and no Git Flow.
+
+1. Create a focused branch: `feature/<topic>` or `fix/<topic>`.
+2. Make a focused change; avoid bundling unrelated edits.
+3. Add or update tests for any behavioral change.
+4. Update documentation (README, docstrings, `CHANGELOG.md`) when user-facing behavior changes.
+5. Open a pull request against `main` and make sure CI passes.
+
+## Linting
+
+The repository uses [Trunk](https://docs.trunk.io) for linting and formatting; it runs automatically in CI. Running it locally before pushing is optional:
+
+```bash
+./trunk check
+```
+
+## Bugs and feature requests
+
+Please use the issue forms on the [issue tracker](https://github.com/depablolab/g2rins/issues). For bugs, a minimal reproducer and the G²RINS input string (when applicable) make fixes much faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ python -m pip install -e ".[test]"
 python -m pytest tests/
 ```
 
-CI runs the same suite on Linux, Windows, and macOS with the minimum (3.10) and maximum (3.14) supported Python versions, so passing locally on one platform is usually enough before opening a pull request.
+CI runs the same test suite on Linux, Windows, and macOS using Python 3.10 (the minimum supported version) and Python 3.14 (the highest version currently tested in CI). Pull requests use a faster Linux-only matrix for these two Python versions, while the full cross-platform matrix runs after changes are merged to `main` and on the monthly scheduled CI run. Passing the pull-request checks provides the pre-merge regression gate; the post-merge matrix provides the final cross-platform compatibility check.
 
 ## Contribution workflow
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # G<sup>2</sup>RINS
 
+[![CI](https://github.com/depablolab/g2rins/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/depablolab/g2rins/actions/workflows/ci.yml)
+[![License: GPL-3.0-only](https://img.shields.io/badge/license-GPL--3.0--only-blue.svg)](LICENSE)
+
 Implementation of G2RINS, a line-and-graph representation of polymers. Grammar validation, generative graph construction, and molecular ensemble generation.
 
 ---
@@ -56,6 +59,18 @@ G²RINS is the evolution of **G-BigSMILES** ([latest repository](https://github.
 > Schneider, Walsh, Olsen, de Pablo, *Generative BigSMILES: an extension for polymer informatics, computer simulations & ML/AI*, Digital Discovery **3**, 51–61 (2024). [doi:10.1039/D3DD00147D](https://doi.org/10.1039/D3DD00147D)
 
 A publication describing G²RINS is in preparation.
+
+---
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports and feature requests go through the [issue tracker](https://github.com/depablolab/g2rins/issues); notable changes are tracked in [CHANGELOG.md](CHANGELOG.md) and on the [releases page](https://github.com/depablolab/g2rins/releases).
+
+---
+
+## Citing
+
+If you use G²RINS in your work, please cite the software using the metadata in [CITATION.cff](CITATION.cff) (GitHub's "Cite this repository" button). The citation for the publication describing G²RINS will be added here once it is available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Worked examples are in [`G2RINS_guide.ipynb`](G2RINS_guide.ipynb).
 
 G²RINS is the evolution of **G-BigSMILES** ([latest repository](https://github.com/gervasiozaldivar/G-BigSMILES), [original repository](https://github.com/InnocentBug/G-BigSMILES)), which extends the [BigSMILES line notation](https://olsenlabmit.github.io/BigSMILES/docs/line_notation.html):
 
-> Schneider, Walsh, Olsen, de Pablo, *Generative BigSMILES: an extension for polymer informatics, computer simulations & ML/AI*, Digital Discovery **3**, 51–61 (2024). [doi:10.1039/D3DD00147D](https://doi.org/10.1039/D3DD00147D)
+> Schneider, Walsh, Olsen, de Pablo, _Generative BigSMILES: an extension for polymer informatics, computer simulations & ML/AI_, Digital Discovery **3**, 51–61 (2024). [doi:10.1039/D3DD00147D](https://doi.org/10.1039/D3DD00147D)
 
 A publication describing G²RINS is in preparation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # ]
 
 [build-system]
-requires = ["setuptools>=77", "wheel", "setuptools-scm"]
+requires = ["setuptools>=77", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -36,9 +36,6 @@ test = ["pytest"]
 [project.urls]
 Homepage = "https://github.com/depablolab/g2rins"
 Repository = "https://github.com/depablolab/g2rins"
-
-[tool.setuptools.dynamic]
-version = { attr = "g2rins._version.version" }
 
 [tool.setuptools_scm]
 version_file = "src/g2rins/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,4 @@ omit = [
 ]
 
 [tool.setuptools.package-data]
-g2rins = [
-  "data/g2rins.lark",
-]
+g2rins = ["data/g2rins.lark"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # ]
 
 [build-system]
-requires = ["setuptools>=77", "setuptools-scm>=8"]
+requires = ["setuptools>=80", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Follow-up to #1: a maintenance pass making the repository easier to test, contribute to, cite, and release. No scientific code, grammar, or generation behavior is touched.

## 1. CI: two-tier testing with stable required checks

- **Pull requests** run a fast Linux-only pytest matrix on Python 3.10 (minimum supported) and 3.14 (highest currently tested) — 2 jobs instead of 6, catching ordinary regressions before merge.
- **Pushes to `main` and the monthly schedule** run the full Ubuntu/Windows/macOS × 3.10/3.14 compatibility matrix, so complete platform coverage still happens after every merge and on ecosystem drift.
- A **`CI Required`** aggregation job provides one stable check name for branch protection (Rulesets never depend on matrix-generated job names); the trunk job likewise gets the stable display name **`Trunk Check`**.
- Superseded PR runs are auto-cancelled via a concurrency group keyed on the PR number; push/schedule runs use the unique run id and never cancel each other.
- Removed the `trunk-merge/**` push triggers (Trunk's Draft PR merge-queue mode is the intended setup; push-triggered queue branches are unused).
- All workflows on verified-current official action majors (`checkout@v7`, `setup-python@v7`, `upload-artifact@v7`, `download-artifact@v8`; `notebook.yml` was still on `checkout@v2`), with least-privilege `permissions:` and full-history checkouts so `setuptools-scm` derives real tag versions.
- Replaced `which python` with a portable `sys.executable` print (the old form only worked on `windows-latest` because Git-for-Windows' `usr/bin` happens to be on the runner PATH).
- Python 3.14 justification: RDKit publishes 3.14 wheels since 2026.3 (verified on PyPI); the full suite passes locally on 3.14.4 with RDKit 2026.3.5.
- `notebook.yml` stays manual-dispatch; dropped its unused `TESTING_ENV` variable.

## 2. Packaging/versioning

- Removed the `[tool.setuptools.dynamic] version` attribute, which circularly read the `_version.py` that `setuptools-scm` itself generates; `dynamic = ["version"]` + `[tool.setuptools_scm]` is the documented pattern.
- Build requirements: `setuptools>=80`, `setuptools-scm>=8`; dropped the redundant `wheel` entry.
- Tag-derived versions, `g2rins.__version__`, editable installs, and wheel/sdist versions all verified unchanged (see validation).

## 3. Release automation

- `release.yml` split into two jobs: **build validation** on pushes/PRs (stable `Build distribution` check name, now with `twine check --strict`), and a **GitHub Release** job that runs only on future `v*` tags — it downloads the verified artifacts and creates a release with generated notes via the preinstalled `gh` CLI and the built-in token (`contents: write` scoped to that job only).
- Build determinism: release builds are pinned to Python 3.14 (the highest CI-tested version) instead of a floating `3.x`, and the wheel/sdist artifact is uploaded only on `v*` tag runs — PR/main builds validate but don't store artifacts nobody consumes.
- No PyPI publishing and no external credentials introduced. The existing `v1.0.0` tag is untouched.

## 4. Contributor/citation/changelog files

- `CONTRIBUTING.md`: dev setup, canonical test command, plain GitHub flow, and an accurate description of the two-tier CI (3.14 is described as the highest version tested in CI, not a support ceiling — `requires-python` stays `>=3.10` with no upper bound).
- `CITATION.cff`: software citation only, built strictly from verifiable metadata — authors from `pyproject.toml`, `GPL-3.0-only`, version 1.0.0, tag date 2026-08-08. Validated with cffconvert (schema 1.2.0). No ORCID/DOI/publication metadata invented; the G2RINS paper citation can be added when it exists.
- `CHANGELOG.md`: Keep-a-Changelog style; `v1.0.0` entry is "Initial public release" (all the history verifiably supports), linked to the tag tree rather than assuming a GitHub Release object exists for it.

## 5. Issue/PR templates

- Bug form: minimal reproducer, G2RINS input string, expected/actual behavior with traceback, G2RINS/Python/OS/RDKit versions.
- Feature form: use case, desired behavior, optional API/representation sketch, alternatives considered.
- Short PR template with a scientific/behavioral-impact section and a four-item checklist.

## 6. Repository hygiene

- Untracked `.trunk/plugins/trunk`: a committed symlink into one maintainer's local cache path, already covered by `.trunk/.gitignore`; on Windows checkouts it materializes as a broken text file.
- Removed the stale `merge.required_statuses` section from `.trunk/trunk.yaml` (Draft PR merge-queue mode doesn't use it, and its hard-coded names no longer matched the real check names). Required checks are managed via the GitHub Ruleset below.
- Added the new docs' vocabulary to the cspell dictionary; trunk formatter fixes (prettier/taplo) for the touched files.

## 7. Intentionally left unchanged

- All scientific sources under `src/g2rins/`, the grammar, the test suite, and the guide notebook.
- The Trunk linter stack and the root `./trunk` launcher.
- No pre-commit, no CODEOWNERS, no path-based CI skipping (kept required checks simple), no PyPI badge or `pip install g2rins` instructions; installation stays tag-based.

## Validation performed (local: Windows, Python 3.14.4)

- `python -m pip install -e ".[test]"` → correct scm-derived version under `setuptools>=80`
- `python -m pytest tests/` → **303 passed, 4 skipped** (~5 min), on NumPy 2.5.2 / SciPy 1.18.0 / RDKit 2026.3.5 / lark 1.3.1 — run twice (before and after the CI/packaging changes)
- `python -m build` + `twine check --strict dist/*` → PASSED for sdist and wheel; wheel METADATA version matches scm; `g2rins/data/g2rins.lark` present in the wheel
- Fresh-venv install from the built wheel → `import g2rins` OK, `__version__` correct, README quickstart string parses
- `cffconvert --validate` → valid per CFF schema 1.2.0; all workflow/issue-form YAML and `pyproject.toml` parse; all relative doc links resolve
- `./trunk check` locally over changed files → 0 new lint issues (checkov cannot execute under trunk's Windows sandbox — its Ubuntu run in CI is authoritative)
- Hygiene sweep: no `_version.py` or `.trunk/plugins` tracked; no machine-local paths or credentials in the diff; no `src/` files changed
- Windows/macOS runtime coverage is validated by the post-merge Actions matrix, not locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
